### PR TITLE
OPS-7065 Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {},
   "devDependencies": {
     "@shelf/prettier-config": "1.1.1",
-    "oxfmt": "0.55.0"
+    "oxfmt": "0.58.0"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
Updates compatible dependencies, aligned with versions already used by sibling Shelf repositories. Tracks [OPS-7065](https://shelfio.atlassian.net/browse/OPS-7065).

[OPS-7065]: https://gemshelf.atlassian.net/browse/OPS-7065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ